### PR TITLE
Change the wording of last trap restoration command

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-roundcubemail-restore-rh-mariadb105-database
+++ b/root/etc/e-smith/events/actions/nethserver-roundcubemail-restore-rh-mariadb105-database
@@ -24,7 +24,7 @@ set -e
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # echo an error message before exiting
-trap 'echo "Error while restoring roundcubemail database to SCL mariadb105: \"${last_command}\" command filed with exit code $?."' EXIT
+trap 'echo "Roundcubemail DB restoration : \"${last_command}\" command returned exit code $?."' EXIT
 
 source /opt/rh/rh-mariadb105/enable
 


### PR DESCRIPTION
The wording of the last trap command makes to think it is an error, it prints the last command before to exit whatever the exit code

https://github.com/NethServer/dev/issues/6627