### PR TITLE
Remove roundcubemail from obsoletes in specfile

### DIFF
--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -16,7 +16,7 @@ BuildArch: noarch
 BuildRequires: nethserver-devtools
 Requires: nethserver-httpd, nethserver-mail-server
 Conflicts: nethserver-roundcubemail
-Obsoletes: roundcubemail
+#Obsoletes: roundcubemail
 Requires: nethserver-rh-php73-php-fpm
 Requires: rh-php73-php-pspell
 Requires: nethserver-rh-mariadb105 rh-mariadb105-mariadb-server-utils

--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -15,7 +15,8 @@ BuildArch: noarch
 
 BuildRequires: nethserver-devtools
 Requires: nethserver-httpd, nethserver-mail-server
-Conflicts: roundcubemail
+Conflicts: roundcubemail 
+Conflicts: nethserver-roundcubemail
 Requires: nethserver-rh-php73-php-fpm
 Requires: rh-php73-php-pspell
 Requires: nethserver-rh-mariadb105 rh-mariadb105-mariadb-server-utils

--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -16,7 +16,6 @@ BuildArch: noarch
 BuildRequires: nethserver-devtools
 Requires: nethserver-httpd, nethserver-mail-server
 Conflicts: nethserver-roundcubemail
-#Obsoletes: roundcubemail
 Requires: nethserver-rh-php73-php-fpm
 Requires: rh-php73-php-pspell
 Requires: nethserver-rh-mariadb105 rh-mariadb105-mariadb-server-utils

--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -15,7 +15,7 @@ BuildArch: noarch
 
 BuildRequires: nethserver-devtools
 Requires: nethserver-httpd, nethserver-mail-server
-Conflicts: nethserver-roundcubemail
+Conflicts: roundcubemail
 Requires: nethserver-rh-php73-php-fpm
 Requires: rh-php73-php-pspell
 Requires: nethserver-rh-mariadb105 rh-mariadb105-mariadb-server-utils


### PR DESCRIPTION
Due to the `Obsoletes: roundcubemail` line in the spec file the `yum update` is not working when nethserver-roundcubemail is installed.

See also:

https://community.nethserver.org/t/software-update-and-dependency-error/19684

https://github.com/NethServer/dev/issues/6631