### PR TITLE
Upgrade to roundcubemail 1.6.5 and bundle larry skin

### DIFF
--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -2,6 +2,8 @@
 %define rcm_version 1.6.5
 # roundcubemail specific name
 %define rcm_name roundcubemail
+# larry version
+%define larry_version 1.6.1
 
 Summary: NethServer configuration for Roundcube mail client
 Name: nethserver-roundcubemail-next
@@ -11,6 +13,7 @@ License: GPL
 Source: %{name}-%{version}.tar.gz
 Source1: https://github.com/roundcube/%{rcm_name}/releases/download/%{rcm_version}/%{rcm_name}-%{rcm_version}-complete.tar.gz
 Source2: https://github.com/alexandregz/twofactor_gauthenticator/archive/master.zip
+Source3: https://github.com/roundcube/larry/archive/refs/tags/%{larry_version}.zip
 BuildArch: noarch
 
 BuildRequires: nethserver-devtools
@@ -70,6 +73,10 @@ mkdir -p %{buildroot}/usr/share/%{rcm_name}/enigma
 mkdir -p %{buildroot}/usr/share/%{rcm_name}/plugins/twofactor_gauthenticator/
 unzip %{SOURCE2}
 cp -a twofactor_gauthenticator-master/* %{buildroot}/usr/share/%{rcm_name}/plugins/twofactor_gauthenticator/
+#Larry skin
+mkdir -p %{buildroot}/usr/share/%{rcm_name}/skins/larry
+unzip %{SOURCE3}
+cp -a  larry-%{larry_version}/* %{buildroot}/usr/share/%{rcm_name}/skins/larry
 
 %files -f %{version}-%{release}-filelist
 %defattr(-,root,root)
@@ -81,6 +88,7 @@ cp -a twofactor_gauthenticator-master/* %{buildroot}/usr/share/%{rcm_name}/plugi
 %dir %attr(0750,apache,apache) %{_datadir}/%{rcm_name}/enigma
 %dir %attr(0750,apache,apache) /var/log/%{rcm_name}
 %dir %attr(0755,root,root) %{_datadir}/%{rcm_name}/plugins/twofactor_gauthenticator
+%dir %attr(0755,root,root) %{_datadir}/%{rcm_name}/skins/larry
 %dir %attr(0755,root,root) /etc/%{rcm_name}
 %dir %attr(0755,mysql,mysql) /var/opt/rh/rh-mariadb105/lib/mysql-roundcubemail
 

--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -1,5 +1,5 @@
 # roundcubemail specific version
-%define rcm_version 1.5.5
+%define rcm_version 1.6.5
 # roundcubemail specific name
 %define rcm_name roundcubemail
 

--- a/root/etc/e-smith/templates/etc/roundcubemail/config.inc.php/30IMAP_SMTP
+++ b/root/etc/e-smith/templates/etc/roundcubemail/config.inc.php/30IMAP_SMTP
@@ -14,7 +14,7 @@
 // For example %n = mail.domain.tld, %t = domain.tld
 // WARNING: After hostname change update of mail_host column in users table is
 //          required to match old user data records with the new host.
-$config['default_host'] = array(
+$config['imap_host'] = array(
     '{ $roundcubemail{'Server'} || 'localhost' }' => '{ $DomainName }',
     '127.0.0.1' => 'Local'
 );
@@ -85,11 +85,7 @@ $config['messages_cache'] = false;
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
-$config['smtp_server'] = '127.0.0.1';
-
-// SMTP port (default is 25; use 587 for STARTTLS or 465 for the
-// deprecated SSL over SMTP (aka SMTPS))
-$config['smtp_port'] = 10587;
+$config['smtp_host'] = '127.0.0.1:10587';
 
 // SMTP username (if required) if you use %u as the username Roundcube
 // will use the current username for login


### PR DESCRIPTION
We need to upgrade to 1.6.5 for nethserver-roundcubemail-next for compatibility we have to bundle the previous `larry` skin but if you want to change to elastic, then simple do 

```
config setprop roundcubemail skin elastic
signal-event nethserver-roundcubemail-next-update
```