### PR TITLE
Upgrade roundcubemail to version 1.6.8

### DIFF
--- a/nethserver-roundcubemail-next.spec
+++ b/nethserver-roundcubemail-next.spec
@@ -1,5 +1,5 @@
 # roundcubemail specific version
-%define rcm_version 1.6.5
+%define rcm_version 1.6.8
 # roundcubemail specific name
 %define rcm_name roundcubemail
 # larry version


### PR DESCRIPTION
This pull request upgrades the roundcubemail package to version 1.6.8.

https://github.com/NethServer/dev/issues/6999